### PR TITLE
Create a build for PHP 8.2, likely very late.

### DIFF
--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,0 +1,46 @@
+FROM php:8.2-fpm
+
+LABEL Maintainer="Jeremy Brayton"
+
+# apt-get required packages
+RUN apt-get update -yqq && apt-get install -yqq git openssh-client libzip-dev zip unzip iputils-ping libicu-dev libxml2-dev
+
+# PHP extension installation
+RUN docker-php-ext-install pdo_mysql zip bcmath pcntl posix intl soap
+
+# Install iconv and gd
+RUN apt-get install -yqq libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
+    && docker-php-ext-install -j$(nproc) iconv \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
+
+# Install mcrypt
+#RUN apt-get install -yqq libmcrypt-dev \
+#    && pecl install -f mcrypt \
+#    && docker-php-ext-enable mcrypt
+# Unsure if the next part is necessary but it does say -> You should add "extension=mcrypt.so" to php.ini
+#RUN echo "extension=mcrypt.so" > /usr/local/etc/php/conf.d/mcrypt.ini
+
+# Install ssh2
+#RUN apt-get install -yqq libssh2-1 libssh2-1-dev \
+#    && pecl install ssh2 \
+#    && docker-php-ext-enable ssh2
+
+# Install xdebug
+#RUN pecl install xdebug \
+#    && docker-php-ext-enable xdebug
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Environmental variables
+ENV COMPOSER_HOME /root/.composer
+ENV COMPOSER_CACHE_DIR /cache
+ENV PATH /root/.composer/vendor/bin:$PATH
+
+# Install deployer
+RUN composer global require "deployer/deployer"
+RUN composer global require --dev "deployer/recipes"
+
+# Install PHP SSH2 extension
+#RUN composer global require "herzult/php-ssh:~1.1"

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ To support a new version of PHP:
 2. Replicate the prior `Dockerfile`, essentially `cp 7.2/Dockerfile 7.3`.
 3. Change the line `FROM php:7.2-fpm` to `FROM php:7.3-fpm`.
    1. This assumes the internal build tags don't change. Fortunately this tag is rather stable.
-4. Build your new image to test: `docker build ./7.3 -t w0rd-driven/docker-laravel-deployer:7.3`.
+4. Build your new image to test: `docker build ./7.3 -t w0rddriven/docker-laravel-deployer:7.3`.
 5. Troubleshoot any breaking changes.
    1. Occasionally you may have to track a deviation further up the stack.
       1. Since we're running `php:7.3-fpm` you should inspect [the list of supported tags](https://github.com/docker-library/docs/blob/master/php/README.md#supported-tags-and-respective-dockerfile-links) to see what that image is built from.
    2. In the case of 7.3, `libzip` is no longer included so it needs to be added explicitly.
       1. 7.2 also removed extensions so this is the most common type of problem you'll run into.
-   3. Remove any previously cached images via the rmi command: `docker rmi w0rd-driven/docker-laravel-deployer:7.3`.
+   3. Remove any previously cached images via the rmi command: `docker rmi w0rddriven/docker-laravel-deployer:7.3`.
    4. Remove any unused images `docker image prune --all`.
 6. Push the local image to Docker Hub (required as automated builds are no longer enabled)
    1. `docker push w0rddriven/docker-laravel-deployer:8.1`


### PR DESCRIPTION
Fixes #27

Fix README issues, w0rd-driven doesn't work as a user name now. Push wouldn't work because the local version w0rd-driven creates as w0rddriven. It's weird, Docker, deal with it.

I think it likely does create the local dash version but a push doesn't recognize it. Better to just change the name because since it's built, it just remaps to the new name instantly.